### PR TITLE
Service Route Refactor

### DIFF
--- a/src/main/kotlin/com/thiagotoazza/data/models/services/CreateServiceOrderUseCase.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/models/services/CreateServiceOrderUseCase.kt
@@ -1,0 +1,83 @@
+package com.thiagotoazza.data.models.services
+
+import com.thiagotoazza.data.models.customer.Customer
+import com.thiagotoazza.data.models.vehicles.Vehicle
+import com.thiagotoazza.data.source.customer.CustomerDataSource
+import com.thiagotoazza.data.source.report.ReportDataSource
+import com.thiagotoazza.data.source.service.ServiceDataSource
+import com.thiagotoazza.data.source.vehicle.VehicleDataSource
+import com.thiagotoazza.utils.asObjectId
+import com.thiagotoazza.utils.isValidObjectId
+import org.bson.BsonDateTime
+import org.bson.types.ObjectId
+
+class CreateServiceOrderUseCase(
+    private val servicesDataSource: ServiceDataSource,
+    private val customerDataSource: CustomerDataSource,
+    private val vehicleDataSource: VehicleDataSource,
+    private val reportsDataSource: ReportDataSource,
+) {
+    suspend operator fun invoke(washerId: String, request: ServiceRequest): Boolean {
+        val customerId = if (request.vehicle.ownerId.isValidObjectId()) {
+            ObjectId(request.vehicle.ownerId)
+        } else {
+            val customerData = request.customer.run {
+                Customer(
+                    fullName = fullName,
+                    phoneNumber = phoneNumber,
+                    isDeleted = false,
+                    washerId = ObjectId(washerId)
+                )
+            }
+            customerDataSource.insertCustomerV2(customer = customerData).insertedId
+        }
+
+        val vehicleId = if (request.vehicle.id.isValidObjectId()) {
+            ObjectId(request.vehicle.id)
+        } else {
+            val vehicleData = request.vehicle.run {
+                Vehicle(
+                    model = model,
+                    plate = plate,
+                    ownerId = customerId,
+                    washerId = ObjectId(washerId)
+                )
+            }
+            vehicleDataSource.insertVehicleV2(vehicle = vehicleData).insertedId
+        }
+
+        val service = buildService(
+            serviceRequest = request,
+            customerId = customerId ?: throw IllegalArgumentException("customerId may not be null"),
+            vehicleId = vehicleId ?: throw IllegalArgumentException("vehicleId may not be null"),
+            washerId = ObjectId(washerId)
+        )
+
+        val serviceCreated = servicesDataSource.insertService(service).wasAcknowledged
+        if (serviceCreated) {
+            reportsDataSource.upsertReport(service)
+            return true
+        }
+        return false
+    }
+
+
+    private fun buildService(
+        serviceRequest: ServiceRequest,
+        customerId: ObjectId,
+        vehicleId: ObjectId,
+        washerId: ObjectId
+    ): Service {
+        return serviceRequest.run {
+            Service(
+                customerId = customerId,
+                vehicleId = vehicleId,
+                washerId = washerId,
+                date = BsonDateTime(date),
+                typeId = typeId.asObjectId(),
+                cost = cost
+            )
+        }
+    }
+
+}

--- a/src/main/kotlin/com/thiagotoazza/data/models/services/CreateServiceOrderUseCase.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/models/services/CreateServiceOrderUseCase.kt
@@ -7,6 +7,7 @@ import com.thiagotoazza.data.source.customer.CustomerDataSource
 import com.thiagotoazza.data.source.report.ReportDataSource
 import com.thiagotoazza.data.source.service.ServiceDataSource
 import com.thiagotoazza.data.source.vehicle.VehicleDataSource
+import com.thiagotoazza.utils.ApiResult
 import com.thiagotoazza.utils.asObjectId
 import com.thiagotoazza.utils.isValidObjectId
 import org.bson.BsonDateTime
@@ -18,7 +19,7 @@ class CreateServiceOrderUseCase(
     private val vehicleDataSource: VehicleDataSource,
     private val reportsDataSource: ReportDataSource,
 ) {
-    suspend operator fun invoke(washerId: String, request: ServiceRequest): Boolean {
+    suspend operator fun invoke(washerId: String, request: ServiceRequest): ApiResult {
         val clientSession = WashingDatabase.clientSession()
         clientSession.use { session ->
             return try {
@@ -34,10 +35,16 @@ class CreateServiceOrderUseCase(
                             washerId = ObjectId(washerId)
                         )
                     }
-                    customerDataSource.insertCustomerV2(
+                    val result = customerDataSource.insertCustomerV2(
                         customer = customerData,
                         session = session
-                    ).insertedId ?: throw IllegalStateException("Failed to insert customer")
+                    )
+
+                    if (result is ApiResult.Success) {
+                        result.insertedId?.value ?: throw IllegalStateException("Customer inserted, but ID was null")
+                    } else {
+                        throw IllegalStateException("Failed to insert customer")
+                    }
                 }
 
                 val vehicleId = if (request.vehicle.id.isValidObjectId()) {
@@ -51,10 +58,16 @@ class CreateServiceOrderUseCase(
                             washerId = ObjectId(washerId)
                         )
                     }
-                    vehicleDataSource.insertVehicleV2(
+                    val result = vehicleDataSource.insertVehicleV2(
                         vehicle = vehicleData,
                         session = session
-                    ).insertedId ?: throw IllegalStateException("Failed to insert vehicle")
+                    )
+
+                    if (result is ApiResult.Success) {
+                        result.insertedId?.value ?: throw IllegalStateException("Vehicle inserted, but ID was null")
+                    } else {
+                        throw IllegalStateException("Failed to insert vehicle")
+                    }
                 }
 
                 val service = buildService(
@@ -63,22 +76,23 @@ class CreateServiceOrderUseCase(
                     vehicleId = vehicleId,
                     washerId = ObjectId(washerId)
                 )
-                val serviceCreated = servicesDataSource.insertService(service, session).wasAcknowledged
-                if (serviceCreated.not()) {
+                val serviceCreated = servicesDataSource.insertService(service, session)
+                if (serviceCreated is ApiResult.Error) {
                     throw IllegalStateException("Failed to insert service")
                 }
 
-                val reportsUpdated = reportsDataSource.upsertReport(service).wasAcknowledged
-                if (reportsUpdated.not()) {
+                val reportsUpdated = reportsDataSource.upsertReport(service, session)
+                if (reportsUpdated is ApiResult.Error) {
                     throw IllegalStateException("Failed to update report")
                 }
 
                 clientSession.commitTransaction()
-                true
+
+                return serviceCreated
             } catch (e: Exception) {
                 println(e.message)
                 clientSession.abortTransaction()
-                false
+                ApiResult.Error(message = e.message.orEmpty())
             }
         }
     }

--- a/src/main/kotlin/com/thiagotoazza/data/models/services/CreateServiceOrderUseCase.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/models/services/CreateServiceOrderUseCase.kt
@@ -1,5 +1,6 @@
 package com.thiagotoazza.data.models.services
 
+import com.thiagotoazza.data.WashingDatabase
 import com.thiagotoazza.data.models.customer.Customer
 import com.thiagotoazza.data.models.vehicles.Vehicle
 import com.thiagotoazza.data.source.customer.CustomerDataSource
@@ -18,49 +19,69 @@ class CreateServiceOrderUseCase(
     private val reportsDataSource: ReportDataSource,
 ) {
     suspend operator fun invoke(washerId: String, request: ServiceRequest): Boolean {
-        val customerId = if (request.vehicle.ownerId.isValidObjectId()) {
-            ObjectId(request.vehicle.ownerId)
-        } else {
-            val customerData = request.customer.run {
-                Customer(
-                    fullName = fullName,
-                    phoneNumber = phoneNumber,
-                    isDeleted = false,
+        val clientSession = WashingDatabase.clientSession()
+        clientSession.use { session ->
+            return try {
+                session.startTransaction()
+                val customerId = if (request.vehicle.ownerId.isValidObjectId()) {
+                    ObjectId(request.vehicle.ownerId)
+                } else {
+                    val customerData = request.customer.run {
+                        Customer(
+                            fullName = fullName,
+                            phoneNumber = phoneNumber,
+                            isDeleted = false,
+                            washerId = ObjectId(washerId)
+                        )
+                    }
+                    customerDataSource.insertCustomerV2(
+                        customer = customerData,
+                        session = session
+                    ).insertedId ?: throw IllegalStateException("Failed to insert customer")
+                }
+
+                val vehicleId = if (request.vehicle.id.isValidObjectId()) {
+                    ObjectId(request.vehicle.id)
+                } else {
+                    val vehicleData = request.vehicle.run {
+                        Vehicle(
+                            model = model,
+                            plate = plate,
+                            ownerId = customerId,
+                            washerId = ObjectId(washerId)
+                        )
+                    }
+                    vehicleDataSource.insertVehicleV2(
+                        vehicle = vehicleData,
+                        session = session
+                    ).insertedId ?: throw IllegalStateException("Failed to insert vehicle")
+                }
+
+                val service = buildService(
+                    serviceRequest = request,
+                    customerId = customerId,
+                    vehicleId = vehicleId,
                     washerId = ObjectId(washerId)
                 )
+                val serviceCreated = servicesDataSource.insertService(service, session).wasAcknowledged
+                if (serviceCreated.not()) {
+                    throw IllegalStateException("Failed to insert service")
+                }
+
+                val reportsUpdated = reportsDataSource.upsertReport(service).wasAcknowledged
+                if (reportsUpdated.not()) {
+                    throw IllegalStateException("Failed to update report")
+                }
+
+                clientSession.commitTransaction()
+                true
+            } catch (e: Exception) {
+                println(e.message)
+                clientSession.abortTransaction()
+                false
             }
-            customerDataSource.insertCustomerV2(customer = customerData).insertedId
         }
-
-        val vehicleId = if (request.vehicle.id.isValidObjectId()) {
-            ObjectId(request.vehicle.id)
-        } else {
-            val vehicleData = request.vehicle.run {
-                Vehicle(
-                    model = model,
-                    plate = plate,
-                    ownerId = customerId,
-                    washerId = ObjectId(washerId)
-                )
-            }
-            vehicleDataSource.insertVehicleV2(vehicle = vehicleData).insertedId
-        }
-
-        val service = buildService(
-            serviceRequest = request,
-            customerId = customerId ?: throw IllegalArgumentException("customerId may not be null"),
-            vehicleId = vehicleId ?: throw IllegalArgumentException("vehicleId may not be null"),
-            washerId = ObjectId(washerId)
-        )
-
-        val serviceCreated = servicesDataSource.insertService(service).wasAcknowledged
-        if (serviceCreated) {
-            reportsDataSource.upsertReport(service)
-            return true
-        }
-        return false
     }
-
 
     private fun buildService(
         serviceRequest: ServiceRequest,

--- a/src/main/kotlin/com/thiagotoazza/data/source/customer/CustomerDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/customer/CustomerDataSource.kt
@@ -1,12 +1,14 @@
 package com.thiagotoazza.data.source.customer
 
 import com.thiagotoazza.data.models.customer.Customer
+import com.thiagotoazza.utils.ApiResult
 
 interface CustomerDataSource {
     suspend fun getCustomers(): List<Customer>
     suspend fun getCustomersFromWasher(washerId: String): List<Customer>
     suspend fun getCustomerById(id: String?): Customer?
     suspend fun insertCustomer(customer: Customer): Boolean
+    suspend fun insertCustomerV2(customer: Customer): ApiResult
     suspend fun updateCustomer(customer: Customer): Boolean
     suspend fun deleteCustomer(id: String?): Boolean
 }

--- a/src/main/kotlin/com/thiagotoazza/data/source/customer/CustomerDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/customer/CustomerDataSource.kt
@@ -1,5 +1,6 @@
 package com.thiagotoazza.data.source.customer
 
+import com.mongodb.kotlin.client.coroutine.ClientSession
 import com.thiagotoazza.data.models.customer.Customer
 import com.thiagotoazza.utils.ApiResult
 
@@ -8,7 +9,7 @@ interface CustomerDataSource {
     suspend fun getCustomersFromWasher(washerId: String): List<Customer>
     suspend fun getCustomerById(id: String?): Customer?
     suspend fun insertCustomer(customer: Customer): Boolean
-    suspend fun insertCustomerV2(customer: Customer): ApiResult
+    suspend fun insertCustomerV2(customer: Customer, session: ClientSession? = null): ApiResult
     suspend fun updateCustomer(customer: Customer): Boolean
     suspend fun deleteCustomer(id: String?): Boolean
 }

--- a/src/main/kotlin/com/thiagotoazza/data/source/customer/MongoCustomerDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/customer/MongoCustomerDataSource.kt
@@ -2,7 +2,9 @@ package com.thiagotoazza.data.source.customer
 
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.thiagotoazza.data.models.customer.Customer
+import com.thiagotoazza.utils.ApiResult
 import com.thiagotoazza.utils.Constants
+import com.thiagotoazza.utils.toApiResult
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.toList
 import org.bson.Document
@@ -28,6 +30,10 @@ class MongoCustomerDataSource(database: MongoDatabase) : CustomerDataSource {
 
     override suspend fun insertCustomer(customer: Customer): Boolean {
         return customersCollection.insertOne(customer).wasAcknowledged()
+    }
+
+    override suspend fun insertCustomerV2(customer: Customer): ApiResult {
+        return customersCollection.insertOne(customer).toApiResult()
     }
 
     override suspend fun updateCustomer(customer: Customer): Boolean {

--- a/src/main/kotlin/com/thiagotoazza/data/source/customer/MongoCustomerDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/customer/MongoCustomerDataSource.kt
@@ -1,5 +1,7 @@
 package com.thiagotoazza.data.source.customer
 
+import com.mongodb.client.result.InsertOneResult
+import com.mongodb.kotlin.client.coroutine.ClientSession
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.thiagotoazza.data.models.customer.Customer
 import com.thiagotoazza.utils.ApiResult
@@ -32,8 +34,16 @@ class MongoCustomerDataSource(database: MongoDatabase) : CustomerDataSource {
         return customersCollection.insertOne(customer).wasAcknowledged()
     }
 
-    override suspend fun insertCustomerV2(customer: Customer): ApiResult {
-        return customersCollection.insertOne(customer).toApiResult()
+    override suspend fun insertCustomerV2(
+        customer: Customer,
+        session: ClientSession?
+    ): ApiResult {
+        val result = if (session != null) {
+            customersCollection.insertOne(session, customer)
+        } else {
+            customersCollection.insertOne(customer)
+        }
+        return result.toApiResult()
     }
 
     override suspend fun updateCustomer(customer: Customer): Boolean {

--- a/src/main/kotlin/com/thiagotoazza/data/source/report/MongoReportDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/report/MongoReportDataSource.kt
@@ -1,6 +1,7 @@
 package com.thiagotoazza.data.source.report
 
 import com.mongodb.client.model.UpdateOptions
+import com.mongodb.kotlin.client.coroutine.ClientSession
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.thiagotoazza.data.models.report.Report
 import com.thiagotoazza.data.models.services.Service
@@ -31,15 +32,27 @@ class MongoReportDataSource(database: MongoDatabase) : ReportDataSource {
         return reportsCollection.find(query).toList()
     }
 
-    override suspend fun upsertReport(service: Service): ApiResult {
+    override suspend fun upsertReport(
+        service: Service,
+        session: ClientSession?
+    ): ApiResult {
         val shortDate = service.date.value.toShortDate()
         val query = Document(Constants.KEY_DATE, shortDate).append(Constants.KEY_WASHER_ID, service.washerId)
 
-        val result = reportsCollection.updateOne(
-            filter = query,
-            update = Document(ACTION_PUSH, mapOf(KEY_SERVICES to service.id)),
-            options = UpdateOptions().upsert(true)
-        )
+        val result = if (session != null) {
+            reportsCollection.updateOne(
+                filter = query,
+                update = Document(ACTION_PUSH, mapOf(KEY_SERVICES to service.id)),
+                options = UpdateOptions().upsert(true),
+                clientSession = session
+            )
+        } else {
+            reportsCollection.updateOne(
+                filter = query,
+                update = Document(ACTION_PUSH, mapOf(KEY_SERVICES to service.id)),
+                options = UpdateOptions().upsert(true)
+            )
+        }
 
         return ApiResult(
             wasAcknowledged = result.wasAcknowledged(),

--- a/src/main/kotlin/com/thiagotoazza/data/source/report/MongoReportDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/report/MongoReportDataSource.kt
@@ -54,10 +54,11 @@ class MongoReportDataSource(database: MongoDatabase) : ReportDataSource {
             )
         }
 
-        return ApiResult(
-            wasAcknowledged = result.wasAcknowledged(),
-            insertedId = result.upsertedId?.asObjectId()?.value
-        )
+        return if (result.wasAcknowledged()) {
+            ApiResult.Success(insertedId = result.upsertedId?.asObjectId())
+        } else {
+            ApiResult.Error(message = "")
+        }
     }
 
 }

--- a/src/main/kotlin/com/thiagotoazza/data/source/report/MongoReportDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/report/MongoReportDataSource.kt
@@ -1,8 +1,12 @@
 package com.thiagotoazza.data.source.report
 
+import com.mongodb.client.model.UpdateOptions
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.thiagotoazza.data.models.report.Report
+import com.thiagotoazza.data.models.services.Service
+import com.thiagotoazza.utils.ApiResult
 import com.thiagotoazza.utils.Constants
+import com.thiagotoazza.utils.toShortDate
 import kotlinx.coroutines.flow.toList
 import org.bson.Document
 import org.bson.types.ObjectId
@@ -10,6 +14,8 @@ import org.bson.types.ObjectId
 class MongoReportDataSource(database: MongoDatabase) : ReportDataSource {
 
     companion object {
+        private const val ACTION_PUSH = "\$push"
+        private const val KEY_SERVICES = "services"
         const val ACTION_REGEX = "\$regex"
     }
 
@@ -23,6 +29,22 @@ class MongoReportDataSource(database: MongoDatabase) : ReportDataSource {
         val query = Document(Constants.KEY_WASHER_ID, ObjectId(washerId))
             .append(Constants.KEY_DATE, Document(ACTION_REGEX, "^$year-$month"))
         return reportsCollection.find(query).toList()
+    }
+
+    override suspend fun upsertReport(service: Service): ApiResult {
+        val shortDate = service.date.value.toShortDate()
+        val query = Document(Constants.KEY_DATE, shortDate).append(Constants.KEY_WASHER_ID, service.washerId)
+
+        val result = reportsCollection.updateOne(
+            filter = query,
+            update = Document(ACTION_PUSH, mapOf(KEY_SERVICES to service.id)),
+            options = UpdateOptions().upsert(true)
+        )
+
+        return ApiResult(
+            wasAcknowledged = result.wasAcknowledged(),
+            insertedId = result.upsertedId?.asObjectId()?.value
+        )
     }
 
 }

--- a/src/main/kotlin/com/thiagotoazza/data/source/report/ReportDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/report/ReportDataSource.kt
@@ -1,5 +1,6 @@
 package com.thiagotoazza.data.source.report
 
+import com.mongodb.kotlin.client.coroutine.ClientSession
 import com.thiagotoazza.data.models.report.Report
 import com.thiagotoazza.data.models.services.Service
 import com.thiagotoazza.utils.ApiResult
@@ -7,5 +8,5 @@ import com.thiagotoazza.utils.ApiResult
 interface ReportDataSource {
     suspend fun getReports(): List<Report>
     suspend fun getReportsBy(washerId: String?, year: String, month: String): List<Report>?
-    suspend fun upsertReport(service: Service): ApiResult
+    suspend fun upsertReport(service: Service, session: ClientSession? = null): ApiResult
 }

--- a/src/main/kotlin/com/thiagotoazza/data/source/report/ReportDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/report/ReportDataSource.kt
@@ -1,8 +1,11 @@
 package com.thiagotoazza.data.source.report
 
 import com.thiagotoazza.data.models.report.Report
+import com.thiagotoazza.data.models.services.Service
+import com.thiagotoazza.utils.ApiResult
 
 interface ReportDataSource {
     suspend fun getReports(): List<Report>
     suspend fun getReportsBy(washerId: String?, year: String, month: String): List<Report>?
+    suspend fun upsertReport(service: Service): ApiResult
 }

--- a/src/main/kotlin/com/thiagotoazza/data/source/service/MongoServiceDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/service/MongoServiceDataSource.kt
@@ -2,38 +2,28 @@ package com.thiagotoazza.data.source.service
 
 import com.mongodb.client.model.*
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
-import com.thiagotoazza.data.models.customer.Customer
-import com.thiagotoazza.data.models.report.Report
 import com.thiagotoazza.data.models.report.ReportResponse
 import com.thiagotoazza.data.models.report.ReportV2
 import com.thiagotoazza.data.models.services.Service
-import com.thiagotoazza.data.models.services.ServiceRequest
-import com.thiagotoazza.data.models.vehicles.Vehicle
-import com.thiagotoazza.utils.*
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
+import com.thiagotoazza.utils.ApiResult
+import com.thiagotoazza.utils.Constants
+import com.thiagotoazza.utils.DateFilter
+import com.thiagotoazza.utils.toApiResult
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.toList
-import org.bson.BsonDateTime
-import org.bson.BsonInvalidOperationException
 import org.bson.Document
 import org.bson.types.ObjectId
 
 class MongoServiceDataSource(database: MongoDatabase) : ServiceDataSource {
 
     companion object {
-        private const val ACTION_PUSH = "\$push"
         private const val ACTION_TO_DATE = "\$toDate"
         private const val ACTION_DATE_TO_STRING = "\$dateToString"
         private const val AGGREGATION_FORMAT = "%Y-%m-%d"
-        private const val KEY_SERVICES = "services"
         private const val KEY_FORMAT = "format"
     }
 
-    private val customersCollection = database.getCollection<Customer>(Constants.KEY_CUSTOMERS_COLLECTION)
-    private val vehiclesCollection = database.getCollection<Vehicle>(Constants.KEY_VEHICLES_COLLECTION)
     private val servicesCollection = database.getCollection<Service>(Constants.KEY_SERVICES_COLLECTION)
-    private val reportsCollection = database.getCollection<Report>(Constants.KEY_REPORTS_COLLECTION)
 
     override suspend fun getServices(): List<Service> {
         return servicesCollection.find().toList()
@@ -96,62 +86,8 @@ class MongoServiceDataSource(database: MongoDatabase) : ServiceDataSource {
         return servicesCollection.find(query).firstOrNull()
     }
 
-    override suspend fun insertService(washerId: String, serviceRequest: ServiceRequest): Boolean {
-        try {
-            val customerId = coroutineScope {
-                if (serviceRequest.vehicle.ownerId.isValidObjectId()) ObjectId(serviceRequest.vehicle.ownerId)
-                else {
-                    async {
-                        customersCollection.insertOne(serviceRequest.customer.run {
-                            Customer(
-                                fullName = fullName,
-                                phoneNumber = phoneNumber,
-                                isDeleted = false,
-                                washerId = ObjectId(washerId)
-                            )
-                        }).insertedId
-                    }
-                        .await()
-                        ?.asObjectId()
-                        ?.value
-                }
-            }
-
-            val vehicleId = coroutineScope {
-                if (serviceRequest.vehicle.id.isValidObjectId()) ObjectId(serviceRequest.vehicle.id)
-                else {
-                    async {
-                        vehiclesCollection.insertOne(serviceRequest.vehicle.run {
-                            Vehicle(
-                                model = model,
-                                plate = plate,
-                                ownerId = customerId,
-                                washerId = ObjectId(washerId)
-                            )
-                        }).insertedId
-                    }
-                        .await()
-                        ?.asObjectId()
-                        ?.value
-                }
-            }
-
-            val service = buildService(
-                serviceRequest = serviceRequest,
-                customerId = customerId ?: throw IllegalArgumentException("customerId may not be null"),
-                vehicleId = vehicleId ?: throw IllegalArgumentException("vehicleId may not be null"),
-                washerId = ObjectId(washerId)
-            )
-
-            return if (servicesCollection.insertOne(service).wasAcknowledged()) {
-                upsertReport(service)
-            } else {
-                false
-            }
-        } catch (exception: BsonInvalidOperationException) {
-            println(exception.message)
-            return false
-        }
+    override suspend fun insertService(service: Service): ApiResult {
+        return servicesCollection.insertOne(service).toApiResult()
     }
 
     override suspend fun updateService(service: Service): Boolean {
@@ -162,37 +98,6 @@ class MongoServiceDataSource(database: MongoDatabase) : ServiceDataSource {
     override suspend fun deleteService(id: String): Boolean {
         val query = Document("_id", ObjectId(id))
         return servicesCollection.deleteOne(query).wasAcknowledged()
-    }
-
-    private fun buildService(
-        serviceRequest: ServiceRequest,
-        customerId: ObjectId,
-        vehicleId: ObjectId,
-        washerId: ObjectId
-    ): Service {
-        return serviceRequest.run {
-            Service(
-                customerId = customerId,
-                vehicleId = vehicleId,
-                washerId = washerId,
-                date = BsonDateTime(date),
-                typeId = typeId.asObjectId(),
-                cost = cost
-            )
-        }
-    }
-
-    private suspend fun upsertReport(service: Service): Boolean {
-        val shortDate = service.date.value.toShortDate()
-        val query = Document(Constants.KEY_DATE, shortDate).append(Constants.KEY_WASHER_ID, service.washerId)
-
-        val result = reportsCollection.updateOne(
-            filter = query,
-            update = Document(ACTION_PUSH, mapOf(KEY_SERVICES to service.id)),
-            options = UpdateOptions().upsert(true)
-        )
-
-        return result.wasAcknowledged()
     }
 
 }

--- a/src/main/kotlin/com/thiagotoazza/data/source/service/MongoServiceDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/service/MongoServiceDataSource.kt
@@ -1,6 +1,7 @@
 package com.thiagotoazza.data.source.service
 
 import com.mongodb.client.model.*
+import com.mongodb.kotlin.client.coroutine.ClientSession
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.thiagotoazza.data.models.report.ReportResponse
 import com.thiagotoazza.data.models.report.ReportV2
@@ -86,8 +87,16 @@ class MongoServiceDataSource(database: MongoDatabase) : ServiceDataSource {
         return servicesCollection.find(query).firstOrNull()
     }
 
-    override suspend fun insertService(service: Service): ApiResult {
-        return servicesCollection.insertOne(service).toApiResult()
+    override suspend fun insertService(
+        service: Service,
+        session: ClientSession?
+    ): ApiResult {
+        val result = if (session != null) {
+            servicesCollection.insertOne(session, service)
+        } else {
+            servicesCollection.insertOne(service)
+        }
+        return result.toApiResult()
     }
 
     override suspend fun updateService(service: Service): Boolean {

--- a/src/main/kotlin/com/thiagotoazza/data/source/service/ServiceDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/service/ServiceDataSource.kt
@@ -2,7 +2,7 @@ package com.thiagotoazza.data.source.service
 
 import com.thiagotoazza.data.models.report.ReportV2
 import com.thiagotoazza.data.models.services.Service
-import com.thiagotoazza.data.models.services.ServiceRequest
+import com.thiagotoazza.utils.ApiResult
 import com.thiagotoazza.utils.DateFilter
 
 interface ServiceDataSource {
@@ -10,7 +10,7 @@ interface ServiceDataSource {
     suspend fun getServices(washerId: String): List<Service>
     suspend fun getServicesByWasherIdAndDate(washerId: String, dateFilter: DateFilter): List<ReportV2>
     suspend fun getServicesById(id: String?): Service?
-    suspend fun insertService(washerId: String, serviceRequest: ServiceRequest): Boolean
+    suspend fun insertService(service: Service): ApiResult
     suspend fun updateService(service: Service): Boolean
     suspend fun deleteService(id: String): Boolean
 }

--- a/src/main/kotlin/com/thiagotoazza/data/source/service/ServiceDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/service/ServiceDataSource.kt
@@ -1,5 +1,6 @@
 package com.thiagotoazza.data.source.service
 
+import com.mongodb.kotlin.client.coroutine.ClientSession
 import com.thiagotoazza.data.models.report.ReportV2
 import com.thiagotoazza.data.models.services.Service
 import com.thiagotoazza.utils.ApiResult
@@ -10,7 +11,7 @@ interface ServiceDataSource {
     suspend fun getServices(washerId: String): List<Service>
     suspend fun getServicesByWasherIdAndDate(washerId: String, dateFilter: DateFilter): List<ReportV2>
     suspend fun getServicesById(id: String?): Service?
-    suspend fun insertService(service: Service): ApiResult
+    suspend fun insertService(service: Service, session: ClientSession? = null): ApiResult
     suspend fun updateService(service: Service): Boolean
     suspend fun deleteService(id: String): Boolean
 }

--- a/src/main/kotlin/com/thiagotoazza/data/source/vehicle/MongoVehicleDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/vehicle/MongoVehicleDataSource.kt
@@ -2,7 +2,9 @@ package com.thiagotoazza.data.source.vehicle
 
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.thiagotoazza.data.models.vehicles.Vehicle
+import com.thiagotoazza.utils.ApiResult
 import com.thiagotoazza.utils.Constants
+import com.thiagotoazza.utils.toApiResult
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.toList
 import org.bson.Document
@@ -49,6 +51,10 @@ class MongoVehicleDataSource(database: MongoDatabase) : VehicleDataSource {
 
     override suspend fun insertVehicle(vehicle: Vehicle): Boolean {
         return vehiclesCollection.insertOne(vehicle).wasAcknowledged()
+    }
+
+    override suspend fun insertVehicleV2(vehicle: Vehicle): ApiResult {
+        return vehiclesCollection.insertOne(vehicle).toApiResult()
     }
 
     override suspend fun updateVehicle(vehicle: Vehicle): Boolean {

--- a/src/main/kotlin/com/thiagotoazza/data/source/vehicle/MongoVehicleDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/vehicle/MongoVehicleDataSource.kt
@@ -1,5 +1,6 @@
 package com.thiagotoazza.data.source.vehicle
 
+import com.mongodb.kotlin.client.coroutine.ClientSession
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.thiagotoazza.data.models.vehicles.Vehicle
 import com.thiagotoazza.utils.ApiResult
@@ -53,8 +54,13 @@ class MongoVehicleDataSource(database: MongoDatabase) : VehicleDataSource {
         return vehiclesCollection.insertOne(vehicle).wasAcknowledged()
     }
 
-    override suspend fun insertVehicleV2(vehicle: Vehicle): ApiResult {
-        return vehiclesCollection.insertOne(vehicle).toApiResult()
+    override suspend fun insertVehicleV2(vehicle: Vehicle, session: ClientSession?): ApiResult {
+        val result = if (session != null) {
+            vehiclesCollection.insertOne(session, vehicle)
+        } else {
+            vehiclesCollection.insertOne(vehicle)
+        }
+        return result.toApiResult()
     }
 
     override suspend fun updateVehicle(vehicle: Vehicle): Boolean {

--- a/src/main/kotlin/com/thiagotoazza/data/source/vehicle/VehicleDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/vehicle/VehicleDataSource.kt
@@ -1,6 +1,7 @@
 package com.thiagotoazza.data.source.vehicle
 
 import com.thiagotoazza.data.models.vehicles.Vehicle
+import com.thiagotoazza.utils.ApiResult
 
 interface VehicleDataSource {
     suspend fun getVehicles(includeDeleted: Boolean = false): List<Vehicle>
@@ -8,6 +9,7 @@ interface VehicleDataSource {
     suspend fun getVehicleById(id: String?): Vehicle?
     suspend fun getVehicleByPlate(plate: String, washerId: String? = null): Vehicle?
     suspend fun insertVehicle(vehicle: Vehicle): Boolean
+    suspend fun insertVehicleV2(vehicle: Vehicle): ApiResult
     suspend fun updateVehicle(vehicle: Vehicle): Boolean
     suspend fun deleteVehicle(id: String?): Boolean
     suspend fun softDeleteVehicle(id: String?): Boolean

--- a/src/main/kotlin/com/thiagotoazza/data/source/vehicle/VehicleDataSource.kt
+++ b/src/main/kotlin/com/thiagotoazza/data/source/vehicle/VehicleDataSource.kt
@@ -1,5 +1,6 @@
 package com.thiagotoazza.data.source.vehicle
 
+import com.mongodb.kotlin.client.coroutine.ClientSession
 import com.thiagotoazza.data.models.vehicles.Vehicle
 import com.thiagotoazza.utils.ApiResult
 
@@ -9,7 +10,7 @@ interface VehicleDataSource {
     suspend fun getVehicleById(id: String?): Vehicle?
     suspend fun getVehicleByPlate(plate: String, washerId: String? = null): Vehicle?
     suspend fun insertVehicle(vehicle: Vehicle): Boolean
-    suspend fun insertVehicleV2(vehicle: Vehicle): ApiResult
+    suspend fun insertVehicleV2(vehicle: Vehicle, session: ClientSession? = null): ApiResult
     suspend fun updateVehicle(vehicle: Vehicle): Boolean
     suspend fun deleteVehicle(id: String?): Boolean
     suspend fun softDeleteVehicle(id: String?): Boolean

--- a/src/main/kotlin/com/thiagotoazza/di/AppModule.kt
+++ b/src/main/kotlin/com/thiagotoazza/di/AppModule.kt
@@ -2,12 +2,15 @@ package com.thiagotoazza.di
 
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.thiagotoazza.data.WashingDatabase
+import com.thiagotoazza.data.models.services.CreateServiceOrderUseCase
 import com.thiagotoazza.data.source.company.CompanyDataSource
 import com.thiagotoazza.data.source.company.MongoCompanyDataSource
 import com.thiagotoazza.data.source.customer.CustomerDataSource
 import com.thiagotoazza.data.source.customer.MongoCustomerDataSource
 import com.thiagotoazza.data.source.report.MongoReportDataSource
+import com.thiagotoazza.data.source.report.ReportDataSource
 import com.thiagotoazza.data.source.service.MongoServiceDataSource
+import com.thiagotoazza.data.source.service.ServiceDataSource
 import com.thiagotoazza.data.source.service_type.MongoServiceTypeDataSource
 import com.thiagotoazza.data.source.service_type.ServiceTypeDataSource
 import com.thiagotoazza.data.source.user.MongoUserDataSource
@@ -30,9 +33,9 @@ val appModule = module {
     single<SHA256HashingService> { SHA256HashingService() } bind HashingService::class
 
     singleOf(::MongoUserDataSource) bind UserDataSource::class
-    singleOf(::MongoReportDataSource)
-    singleOf(::MongoServiceDataSource)
-    singleOf(::MongoCustomerDataSource)
+    singleOf(::MongoReportDataSource) bind ReportDataSource::class
+    singleOf(::MongoServiceDataSource) bind ServiceDataSource::class
+    singleOf(::MongoCustomerDataSource) bind CustomerDataSource::class
     singleOf(::MongoCustomerDataSource) bind CustomerDataSource::class
     singleOf(::MongoVehicleDataSource) bind VehicleDataSource::class
     singleOf(::MongoServiceTypeDataSource) bind ServiceTypeDataSource::class
@@ -53,4 +56,6 @@ val appModule = module {
     singleOf(::ReportsRoute)
     singleOf(::ServiceTypeRoute)
     singleOf(::CompaniesRoute)
+
+    singleOf(::CreateServiceOrderUseCase)
 }

--- a/src/main/kotlin/com/thiagotoazza/routes/ServicesRoute.kt
+++ b/src/main/kotlin/com/thiagotoazza/routes/ServicesRoute.kt
@@ -5,10 +5,7 @@ import com.thiagotoazza.data.models.customer.Customer
 import com.thiagotoazza.data.models.customer.toCustomerResponse
 import com.thiagotoazza.data.models.report.ReportResponse
 import com.thiagotoazza.data.models.report.ReportV2
-import com.thiagotoazza.data.models.services.Service
-import com.thiagotoazza.data.models.services.ServiceRequest
-import com.thiagotoazza.data.models.services.ServiceResponse
-import com.thiagotoazza.data.models.services.toServiceResponse
+import com.thiagotoazza.data.models.services.*
 import com.thiagotoazza.data.models.vehicles.Vehicle
 import com.thiagotoazza.data.models.vehicles.toVehicleResponse
 import com.thiagotoazza.data.source.customer.MongoCustomerDataSource
@@ -36,7 +33,8 @@ class ServicesRoute(
     private val servicesDataSource: MongoServiceDataSource,
     private val customersDataSource: MongoCustomerDataSource,
     private val vehiclesDataSource: MongoVehicleDataSource,
-    private val serviceTypeDataSource: ServiceTypeDataSource
+    private val serviceTypeDataSource: ServiceTypeDataSource,
+    private val createServiceOrderUseCase: CreateServiceOrderUseCase,
 ) {
 
     fun Route.servicesRoute() {
@@ -100,8 +98,8 @@ class ServicesRoute(
                 val washerId = call.parameters[Constants.KEY_WASHER_ID]
                 val request = call.receive<ServiceRequest>()
 
-                if (servicesDataSource.insertService(washerId.orEmpty(), request)) {
-                    call.respond(HttpStatusCode.OK, request)
+                if (createServiceOrderUseCase.invoke(washerId.orEmpty(), request)) {
+                    call.respond(HttpStatusCode.Created, request)
                 } else {
                     call.respond(HttpStatusCode.Conflict)
                 }

--- a/src/main/kotlin/com/thiagotoazza/routes/ServicesRoute.kt
+++ b/src/main/kotlin/com/thiagotoazza/routes/ServicesRoute.kt
@@ -97,17 +97,29 @@ class ServicesRoute(
             post {
                 val washerId = call.parameters[Constants.KEY_WASHER_ID]
                 val request = call.receive<ServiceRequest>()
+                val createServiceResult = createServiceOrderUseCase.invoke(washerId.orEmpty(), request)
 
-                if (createServiceOrderUseCase.invoke(washerId.orEmpty(), request)) {
-                    call.respond(HttpStatusCode.Created, request)
-                } else {
-                    call.respond(HttpStatusCode.Conflict)
+                when (createServiceResult) {
+                    is ApiResult.Success -> {
+                        call.respond(HttpStatusCode.Created, request)
+                    }
+
+                    is ApiResult.Error -> {
+                        call.respond(
+                            status = HttpStatusCode.Conflict,
+                            message = ResponseError(
+                                code = HttpStatusCode.Conflict.value,
+                                message = createServiceResult.message
+                            )
+                        )
+                    }
                 }
             }
 
             put("/{id}") {
                 val washerId = call.parameters[Constants.KEY_WASHER_ID].orEmpty()
-                val serviceId = call.parameters[Constants.KEY_ID] ?: return@put call.respond(HttpStatusCode.BadRequest)
+                val serviceId =
+                    call.parameters[Constants.KEY_ID] ?: return@put call.respond(HttpStatusCode.BadRequest)
                 val service = servicesDataSource.getServicesById(serviceId)
                 val serviceResponse = call.receive<ServiceRequest>().run {
                     async {

--- a/src/main/kotlin/com/thiagotoazza/utils/ApiResult.kt
+++ b/src/main/kotlin/com/thiagotoazza/utils/ApiResult.kt
@@ -1,0 +1,8 @@
+package com.thiagotoazza.utils
+
+import org.bson.types.ObjectId
+
+data class ApiResult(
+    val wasAcknowledged: Boolean,
+    val insertedId: ObjectId?
+)

--- a/src/main/kotlin/com/thiagotoazza/utils/ApiResult.kt
+++ b/src/main/kotlin/com/thiagotoazza/utils/ApiResult.kt
@@ -1,8 +1,14 @@
 package com.thiagotoazza.utils
 
-import org.bson.types.ObjectId
+import org.bson.BsonObjectId
 
-data class ApiResult(
-    val wasAcknowledged: Boolean,
-    val insertedId: ObjectId?
-)
+sealed class ApiResult {
+    data class Success(
+        val insertedId: BsonObjectId?,
+    ) : ApiResult()
+
+    data class Error(
+        val message: String,
+        val exception: Exception? = null
+    ) : ApiResult()
+}

--- a/src/main/kotlin/com/thiagotoazza/utils/Extensions.kt
+++ b/src/main/kotlin/com/thiagotoazza/utils/Extensions.kt
@@ -1,10 +1,11 @@
 package com.thiagotoazza.utils
 
+import com.mongodb.client.result.InsertOneResult
+import org.bson.types.ObjectId
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
-import org.bson.types.ObjectId
 
 /*
  * Output example: 2000-12-28
@@ -33,4 +34,11 @@ fun String.asObjectId(): ObjectId {
     } catch (exception: IllegalArgumentException) {
         throw exception
     }
+}
+
+fun InsertOneResult.toApiResult(): ApiResult {
+    return ApiResult(
+        wasAcknowledged = wasAcknowledged(),
+        insertedId = insertedId?.asObjectId()?.value
+    )
 }

--- a/src/main/kotlin/com/thiagotoazza/utils/Extensions.kt
+++ b/src/main/kotlin/com/thiagotoazza/utils/Extensions.kt
@@ -37,8 +37,13 @@ fun String.asObjectId(): ObjectId {
 }
 
 fun InsertOneResult.toApiResult(): ApiResult {
-    return ApiResult(
-        wasAcknowledged = wasAcknowledged(),
-        insertedId = insertedId?.asObjectId()?.value
-    )
+    return if (wasAcknowledged()) {
+        ApiResult.Success(
+            insertedId = this.insertedId?.asObjectId()
+        )
+    } else {
+        ApiResult.Error(
+            message = "Error parsing InsertOneResult"
+        )
+    }
 }


### PR DESCRIPTION
This PR makes a huge improvement on services route:

- It adds a new Create Service Use Case to handle the Service insertion the Use Case now wraps the entire creation workflow inside a withTransaction block.
- Added ClientSession on the DataSources to make it atomic to prevent orphaned customers/vehicles if the service insertion fails).
- Implemented ApiResult sealed classes for safer, more predictable error handling during database operations.